### PR TITLE
Feature/54 Add entity name format

### DIFF
--- a/dbterd/adapters/algos/test_relationship.py
+++ b/dbterd/adapters/algos/test_relationship.py
@@ -20,7 +20,7 @@ def parse(manifest, catalog, **kwargs):
         Tuple(List[Table], List[Ref]): Info of parsed tables and relationships
     """
     # Parse Table
-    tables = base.get_tables(manifest=manifest, catalog=catalog)
+    tables = base.get_tables(manifest=manifest, catalog=catalog, **kwargs)
 
     # Apply selection
     tables = [
@@ -38,7 +38,15 @@ def parse(manifest, catalog, **kwargs):
     relationships = get_relationships(manifest=manifest, **kwargs)
     node_names = [x.node_name for x in tables]
     relationships = [
-        x
+        Ref(
+            name=x.name,
+            table_map=[
+                [t for t in tables if t.node_name == x.table_map[0]][0].name,
+                [t for t in tables if t.node_name == x.table_map[1]][0].name,
+            ],
+            column_map=x.column_map,
+            type=x.type,
+        )
         for x in relationships
         if x.table_map[0] in node_names and x.table_map[1] in node_names
     ]

--- a/dbterd/adapters/algos/test_relationship.py
+++ b/dbterd/adapters/algos/test_relationship.py
@@ -36,11 +36,11 @@ def parse(manifest, catalog, **kwargs):
 
     # Parse Ref
     relationships = get_relationships(manifest=manifest, **kwargs)
-    table_names = [x.name for x in tables]
+    node_names = [x.node_name for x in tables]
     relationships = [
         x
         for x in relationships
-        if x.table_map[0] in table_names and x.table_map[1] in table_names
+        if x.table_map[0] in node_names and x.table_map[1] in node_names
     ]
 
     # Fullfill columns in Tables (due to `select *`)

--- a/dbterd/adapters/filter.py
+++ b/dbterd/adapters/filter.py
@@ -94,11 +94,11 @@ def is_satisfied_by_name(table: Table, rule: str = ""):
         rule (str, optional): Rule def. Defaults to "".
 
     Returns:
-        bool: True if satisfied `starts with` logic applied to Table name
+        bool: True if satisfied `starts with` logic applied to Node name
     """
     if not rule:
         return True
-    return table.name.startswith(rule)
+    return table.node_name.startswith(rule)
 
 
 def is_satisfied_by_exact(table: Table, rule: str = ""):
@@ -113,7 +113,7 @@ def is_satisfied_by_exact(table: Table, rule: str = ""):
     """
     if not rule:
         return True
-    return table.name == rule
+    return table.node_name == rule
 
 
 def is_satisfied_by_schema(table: Table, rule: str = ""):
@@ -149,7 +149,7 @@ def is_satisfied_by_wildcard(table: Table, rule: str = "*"):
     """
     if not rule:
         return True
-    return fnmatch(table.name, rule)
+    return fnmatch(table.node_name, rule)
 
 
 def is_satisfied_by_exposure(table: Table, rule: str = ""):

--- a/dbterd/adapters/meta.py
+++ b/dbterd/adapters/meta.py
@@ -23,6 +23,7 @@ class Table:
     raw_sql: Optional[str] = None
     resource_type: str = "model"
     exposures: Optional[List[str]] = field(default_factory=lambda: [])
+    node_name: str = None
 
 
 @dataclass

--- a/dbterd/cli/params.py
+++ b/dbterd/cli/params.py
@@ -108,7 +108,8 @@ def common_params(func):
         "--entity-name-format",
         "-enf",
         help="Specified the format of the entity node's name",
-        default="None",
+        default="resource.package.model",
+        show_default=True,
         type=click.STRING,
     )
     @functools.wraps(func)

--- a/dbterd/cli/params.py
+++ b/dbterd/cli/params.py
@@ -104,6 +104,13 @@ def common_params(func):
         default=False,
         show_default=True,
     )
+    @click.option(
+        "--entity-name-format",
+        "-enf",
+        help="Specified the format of the entity node's name",
+        default="None",
+        type=click.STRING,
+    )
     @functools.wraps(func)
     def wrapper(*args, **kwargs):
         return func(*args, **kwargs)  # pragma: no cover

--- a/docs/nav/guide/cli-references.md
+++ b/docs/nav/guide/cli-references.md
@@ -351,6 +351,28 @@ Probably used with `--dbt` enabled.
     # the artifacts dir will probably be assumed as: /path/to/dbt/project/target
     ```
 
+### dbterd run --entity-name-format (-enf)
+
+Decide how the table name is generated on the ERD.
+
+By default, the table name is the dbt node name (`resource_type.package_name.model_name`).
+
+Currently, it supports the following keys in the format:
+
+- `resource.package.model` (by default)
+- `database.schema.table`
+- Or any other partial forms e.g. `schema.table`, `resource.model`
+
+**Examples:**
+=== "CLI"
+
+    ```bash
+    dbterd run --entity-name-format resource.package.model # by default
+    dbterd run --entity-name-format database.schema.table # with fqn of the physical tables
+    dbterd run --entity-name-format schema.table # with schema.table only
+    dbterd run --entity-name-format table # with table name only
+    ```
+
 ## dbterd debug
 
 Shows hidden configured values, which will help us to see what configs are passed into and how they are evaluated to be used.

--- a/tests/unit/adapters/algos/test_test_relationship.py
+++ b/tests/unit/adapters/algos/test_test_relationship.py
@@ -238,6 +238,7 @@ class TestAlgoTestRelationship:
                 [
                     Table(
                         name="model.dbt_resto.table1",
+                        node_name="model.dbt_resto.table1",
                         database="--database--",
                         schema="--schema--",
                         columns=[Column(name="name1", data_type="--name1-type--")],
@@ -245,6 +246,7 @@ class TestAlgoTestRelationship:
                     ),
                     Table(
                         name="model.dbt_resto.table_dummy_columns",
+                        node_name="model.dbt_resto.table_dummy_columns",
                         database="--database--",
                         schema="--schema--",
                         columns=[Column()],
@@ -252,6 +254,7 @@ class TestAlgoTestRelationship:
                     ),
                     Table(
                         name="model.dbt_resto.table2",
+                        node_name="model.dbt_resto.table2",
                         database="--database2--",
                         schema="--schema2--",
                         columns=[
@@ -262,6 +265,7 @@ class TestAlgoTestRelationship:
                     ),
                     Table(
                         name="source.dummy.source_table",
+                        node_name="source.dummy.source_table",
                         database="--database--",
                         schema="--schema--",
                         columns=[
@@ -378,8 +382,8 @@ class TestAlgoTestRelationship:
             (
                 DummyManifestWithExposure(),
                 [
-                    dict(table_name="model.dbt_resto.table1", exposure_name="dummy"),
-                    dict(table_name="model.dbt_resto.table2", exposure_name="dummy"),
+                    dict(node_name="model.dbt_resto.table1", exposure_name="dummy"),
+                    dict(node_name="model.dbt_resto.table2", exposure_name="dummy"),
                 ],
             ),
             (

--- a/tests/unit/adapters/algos/test_test_relationship.py
+++ b/tests/unit/adapters/algos/test_test_relationship.py
@@ -284,7 +284,14 @@ class TestAlgoTestRelationship:
             "dbterd.adapters.algos.base.get_compiled_sql",
             return_value="--irrelevant--",
         ) as mock_get_compiled_sql:
-            assert base_algo.get_tables(manifest, catalog) == expected
+            assert (
+                base_algo.get_tables(
+                    manifest,
+                    catalog,
+                    **dict(entity_name_format="resource.package.model")
+                )
+                == expected
+            )
             mock_get_compiled_sql.assert_called()
 
     @pytest.mark.parametrize(

--- a/tests/unit/adapters/targets/d2/test_d2_test_relationship.py
+++ b/tests/unit/adapters/targets/d2/test_d2_test_relationship.py
@@ -14,6 +14,7 @@ class TestD2TestRelationship:
                 [
                     Table(
                         name="model.dbt_resto.table1",
+                        node_name="model.dbt_resto.table1",
                         database="--database--",
                         schema="--schema--",
                         columns=[Column(name="name1", data_type="name1-type")],
@@ -35,6 +36,7 @@ class TestD2TestRelationship:
                 [
                     Table(
                         name="model.dbt_resto.table1",
+                        node_name="model.dbt_resto.table1",
                         database="--database--",
                         schema="--schema--",
                         columns=[Column(name="name1", data_type="name1-type")],
@@ -42,6 +44,7 @@ class TestD2TestRelationship:
                     ),
                     Table(
                         name="model.dbt_resto.table2",
+                        node_name="model.dbt_resto.table2",
                         database="--database2--",
                         schema="--schema2--",
                         columns=[Column(name="name2", data_type="name2-type2")],
@@ -49,6 +52,7 @@ class TestD2TestRelationship:
                     ),
                     Table(
                         name="source.dbt_resto.table3",
+                        node_name="source.dbt_resto.table3",
                         database="--database3--",
                         schema="--schema3--",
                         columns=[Column(name="name3", data_type="name3-type3")],
@@ -93,6 +97,7 @@ class TestD2TestRelationship:
                 [
                     Table(
                         name="model.dbt_resto.table1",
+                        node_name="model.dbt_resto.table1",
                         database="--database--",
                         schema="--schema--",
                         columns=[Column(name="name1", data_type="name1-type")],
@@ -100,6 +105,7 @@ class TestD2TestRelationship:
                     ),
                     Table(
                         name="model.dbt_resto.table2",
+                        node_name="model.dbt_resto.table2",
                         database="--database2--",
                         schema="--schema2--",
                         columns=[Column(name="name2", data_type="name2-type2")],
@@ -127,6 +133,7 @@ class TestD2TestRelationship:
                 [
                     Table(
                         name="model.dbt_resto.table1",
+                        node_name="model.dbt_resto.table1",
                         database="--database--",
                         schema="--schema--",
                         columns=[Column(name="name1", data_type="name1-type")],
@@ -144,6 +151,7 @@ class TestD2TestRelationship:
                 [
                     Table(
                         name="model.dbt_resto.table1",
+                        node_name="model.dbt_resto.table1",
                         database="--database--",
                         schema="--schema--",
                         columns=[Column(name="name1", data_type="name1-type")],
@@ -151,6 +159,7 @@ class TestD2TestRelationship:
                     ),
                     Table(
                         name="model.dbt_resto.table2",
+                        node_name="model.dbt_resto.table2",
                         database="--database--",
                         schema="--schema--",
                         columns=[Column(name="name2", data_type="name2-type")],
@@ -172,6 +181,7 @@ class TestD2TestRelationship:
                 [
                     Table(
                         name="model.dbt_resto.table1",
+                        node_name="model.dbt_resto.table1",
                         database="--database--",
                         schema="--schema--",
                         columns=[Column(name="name1", data_type="name1-type")],
@@ -193,6 +203,7 @@ class TestD2TestRelationship:
                 [
                     Table(
                         name="model.dbt_resto.table1",
+                        node_name="model.dbt_resto.table1",
                         database="--database--",
                         schema="--schema--",
                         columns=[Column(name="name1", data_type="name1-type")],
@@ -200,6 +211,7 @@ class TestD2TestRelationship:
                     ),
                     Table(
                         name="model.dbt_resto.table2",
+                        node_name="model.dbt_resto.table2",
                         database="--database--",
                         schema="--schema--",
                         columns=[Column(name="name2", data_type="name2-type")],

--- a/tests/unit/adapters/targets/dbml/test_dbml_test_relationship.py
+++ b/tests/unit/adapters/targets/dbml/test_dbml_test_relationship.py
@@ -14,6 +14,7 @@ class TestDbmlTestRelationship:
                 [
                     Table(
                         name="model.dbt_resto.table1",
+                        node_name="model.dbt_resto.table1",
                         database="--database--",
                         schema="--schema--",
                         columns=[
@@ -42,6 +43,7 @@ class TestDbmlTestRelationship:
                 [
                     Table(
                         name="model.dbt_resto.table1",
+                        node_name="model.dbt_resto.table1",
                         database="--database--",
                         schema="--schema--",
                         columns=[Column(name="name1", data_type="--name1-type--")],
@@ -49,6 +51,7 @@ class TestDbmlTestRelationship:
                     ),
                     Table(
                         name="model.dbt_resto.table2",
+                        node_name="model.dbt_resto.table2",
                         database="--database2--",
                         schema="--schema2--",
                         columns=[Column(name="name2", data_type="--name2-type2--")],
@@ -56,6 +59,7 @@ class TestDbmlTestRelationship:
                     ),
                     Table(
                         name="source.dbt_resto.table3",
+                        node_name="source.dbt_resto.table3",
                         database="--database3--",
                         schema="--schema3--",
                         columns=[Column(name="name3", data_type="--name3-type3--")],
@@ -101,6 +105,7 @@ class TestDbmlTestRelationship:
                 [
                     Table(
                         name="model.dbt_resto.table1",
+                        node_name="model.dbt_resto.table1",
                         database="--database--",
                         schema="--schema--",
                         columns=[Column(name="name1", data_type="--name1-type--")],
@@ -108,6 +113,7 @@ class TestDbmlTestRelationship:
                     ),
                     Table(
                         name="model.dbt_resto.table2",
+                        node_name="model.dbt_resto.table2",
                         database="--database2--",
                         schema="--schema2--",
                         columns=[Column(name="name2", data_type="--name2-type2--")],
@@ -136,6 +142,7 @@ class TestDbmlTestRelationship:
                 [
                     Table(
                         name="model.dbt_resto.table1",
+                        node_name="model.dbt_resto.table1",
                         database="--database--",
                         schema="--schema--",
                         columns=[Column(name="name1", data_type="--name1-type--")],
@@ -154,6 +161,7 @@ class TestDbmlTestRelationship:
                 [
                     Table(
                         name="model.dbt_resto.table1",
+                        node_name="model.dbt_resto.table1",
                         database="--database--",
                         schema="--schema--",
                         columns=[Column(name="name1", data_type="name1-type")],
@@ -161,6 +169,7 @@ class TestDbmlTestRelationship:
                     ),
                     Table(
                         name="model.dbt_resto.table2",
+                        node_name="model.dbt_resto.table2",
                         database="--database--",
                         schema="--schema--",
                         columns=[Column(name="name2", data_type="name2-type")],
@@ -183,6 +192,7 @@ class TestDbmlTestRelationship:
                 [
                     Table(
                         name="model.dbt_resto.table1",
+                        node_name="model.dbt_resto.table1",
                         database="--database--",
                         schema="--schema--",
                         columns=[Column(name="name1", data_type="name1-type")],
@@ -190,6 +200,7 @@ class TestDbmlTestRelationship:
                     ),
                     Table(
                         name="model.dbt_resto.view2",
+                        node_name="model.dbt_resto.view2",
                         database="--database--",
                         schema="--schema--",
                         columns=[Column(name="name2", data_type="name2-type")],
@@ -197,6 +208,7 @@ class TestDbmlTestRelationship:
                     ),
                     Table(
                         name="source.dbt_resto.table3",
+                        node_name="source.dbt_resto.table3",
                         database="--database3--",
                         schema="--schema3--",
                         columns=[Column(name="name3", data_type="name3-type3")],
@@ -223,6 +235,7 @@ class TestDbmlTestRelationship:
                 [
                     Table(
                         name="model.dbt_resto.table1",
+                        node_name="model.dbt_resto.table1",
                         database="--database--",
                         schema="--schema--",
                         columns=[Column(name="name1", data_type="name1-type")],
@@ -246,6 +259,7 @@ class TestDbmlTestRelationship:
                 [
                     Table(
                         name="model.dbt_resto.table1",
+                        node_name="model.dbt_resto.table1",
                         database="--database--",
                         schema="--schema--",
                         columns=[Column(name="name1", data_type="name1-type")],
@@ -254,6 +268,7 @@ class TestDbmlTestRelationship:
                     ),
                     Table(
                         name="model.dbt_resto.table23",
+                        node_name="model.dbt_resto.table23",
                         database="--database--",
                         schema="--schema--",
                         columns=[Column(name="name23", data_type="name23-type")],

--- a/tests/unit/adapters/targets/graphviz/test_graphviz_test_relationship.py
+++ b/tests/unit/adapters/targets/graphviz/test_graphviz_test_relationship.py
@@ -14,6 +14,7 @@ class TestGraphVizTestRelationship:
                 [
                     Table(
                         name="model.dbt_resto.table1",
+                        node_name="model.dbt_resto.table1",
                         database="--database--",
                         schema="--schema--",
                         columns=[Column(name="name1", data_type="name1-type")],
@@ -49,6 +50,7 @@ class TestGraphVizTestRelationship:
                 [
                     Table(
                         name="model.dbt_resto.table1",
+                        node_name="model.dbt_resto.table1",
                         database="--database--",
                         schema="--schema--",
                         columns=[Column(name="name1", data_type="name1-type")],
@@ -56,6 +58,7 @@ class TestGraphVizTestRelationship:
                     ),
                     Table(
                         name="model.dbt_resto.table2",
+                        node_name="model.dbt_resto.table2",
                         database="--database2--",
                         schema="--schema2--",
                         columns=[Column(name="name2", data_type="name2-type2")],
@@ -63,6 +66,7 @@ class TestGraphVizTestRelationship:
                     ),
                     Table(
                         name="source.dbt_resto.table3",
+                        node_name="source.dbt_resto.table3",
                         database="--database3--",
                         schema="--schema3--",
                         columns=[Column(name="name3", data_type="name3-type3")],
@@ -147,6 +151,7 @@ class TestGraphVizTestRelationship:
                 [
                     Table(
                         name="model.dbt_resto.table1",
+                        node_name="model.dbt_resto.table1",
                         database="--database--",
                         schema="--schema--",
                         columns=[Column(name="name1", data_type="name1-type")],
@@ -154,6 +159,7 @@ class TestGraphVizTestRelationship:
                     ),
                     Table(
                         name="model.dbt_resto.table2",
+                        node_name="model.dbt_resto.table2",
                         database="--database2--",
                         schema="--schema2--",
                         columns=[Column(name="name2", data_type="name2-type2")],
@@ -195,6 +201,7 @@ class TestGraphVizTestRelationship:
                 [
                     Table(
                         name="model.dbt_resto.table1",
+                        node_name="model.dbt_resto.table1",
                         database="--database--",
                         schema="--schema--",
                         columns=[Column(name="name1", data_type="name1-type")],
@@ -218,6 +225,7 @@ class TestGraphVizTestRelationship:
                 [
                     Table(
                         name="model.dbt_resto.table1",
+                        node_name="model.dbt_resto.table1",
                         database="--database--",
                         schema="--schema--",
                         columns=[Column(name="name1", data_type="name1-type")],
@@ -225,6 +233,7 @@ class TestGraphVizTestRelationship:
                     ),
                     Table(
                         name="model.dbt_resto.table2",
+                        node_name="model.dbt_resto.table2",
                         database="--database--",
                         schema="--schema--",
                         columns=[Column(name="name2", data_type="name2-type")],
@@ -260,6 +269,7 @@ class TestGraphVizTestRelationship:
                 [
                     Table(
                         name="model.dbt_resto.table1",
+                        node_name="model.dbt_resto.table1",
                         database="--database--",
                         schema="--schema--",
                         columns=[Column(name="name1", data_type="name1-type")],
@@ -295,6 +305,7 @@ class TestGraphVizTestRelationship:
                 [
                     Table(
                         name="model.dbt_resto.table1",
+                        node_name="model.dbt_resto.table1",
                         database="--database--",
                         schema="--schema--",
                         columns=[Column(name="name1", data_type="name1-type")],
@@ -302,6 +313,7 @@ class TestGraphVizTestRelationship:
                     ),
                     Table(
                         name="model.dbt_resto.table2",
+                        node_name="model.dbt_resto.table2",
                         database="--database--",
                         schema="--schema--",
                         columns=[Column(name="name2", data_type="name2-type")],

--- a/tests/unit/adapters/targets/mermaid/test_mermaid_test_relationship.py
+++ b/tests/unit/adapters/targets/mermaid/test_mermaid_test_relationship.py
@@ -14,6 +14,7 @@ class TestMermaidTestRelationship:
                 [
                     Table(
                         name="model.dbt_resto.table1",
+                        node_name="model.dbt_resto.table1",
                         database="--database--",
                         schema="--schema--",
                         columns=[Column(name="name1", data_type="name1-type")],
@@ -34,6 +35,7 @@ class TestMermaidTestRelationship:
                 [
                     Table(
                         name="model.dbt_resto.table1",
+                        node_name="model.dbt_resto.table1",
                         database="--database--",
                         schema="--schema--",
                         columns=[Column(name="name1", data_type="name1-type")],
@@ -41,6 +43,7 @@ class TestMermaidTestRelationship:
                     ),
                     Table(
                         name="model.dbt_resto.table2",
+                        node_name="model.dbt_resto.table2",
                         database="--database2--",
                         schema="--schema2--",
                         columns=[Column(name="name2", data_type="name2-type2")],
@@ -48,6 +51,7 @@ class TestMermaidTestRelationship:
                     ),
                     Table(
                         name="source.dbt_resto.table3",
+                        node_name="source.dbt_resto.table3",
                         database="--database3--",
                         schema="--schema3--",
                         columns=[Column(name="name3", data_type="name3-type3")],
@@ -89,6 +93,7 @@ class TestMermaidTestRelationship:
                 [
                     Table(
                         name="model.dbt_resto.table1",
+                        node_name="model.dbt_resto.table1",
                         database="--database--",
                         schema="--schema--",
                         columns=[Column(name="name1", data_type="name1-type")],
@@ -96,6 +101,7 @@ class TestMermaidTestRelationship:
                     ),
                     Table(
                         name="model.dbt_resto.table2",
+                        node_name="model.dbt_resto.table2",
                         database="--database2--",
                         schema="--schema2--",
                         columns=[Column(name="name2", data_type="name2-type2")],
@@ -122,6 +128,7 @@ class TestMermaidTestRelationship:
                 [
                     Table(
                         name="model.dbt_resto.table1",
+                        node_name="model.dbt_resto.table1",
                         database="--database--",
                         schema="--schema--",
                         columns=[Column(name="name1", data_type="name1-type")],
@@ -139,6 +146,7 @@ class TestMermaidTestRelationship:
                 [
                     Table(
                         name="model.dbt_resto.table1",
+                        node_name="model.dbt_resto.table1",
                         database="--database--",
                         schema="--schema--",
                         columns=[Column(name="name1", data_type="name1-type")],
@@ -146,6 +154,7 @@ class TestMermaidTestRelationship:
                     ),
                     Table(
                         name="model.dbt_resto.table2",
+                        node_name="model.dbt_resto.table2",
                         database="--database--",
                         schema="--schema--",
                         columns=[Column(name="name2", data_type="name2-type")],
@@ -166,6 +175,7 @@ class TestMermaidTestRelationship:
                 [
                     Table(
                         name="model.dbt_resto.table1",
+                        node_name="model.dbt_resto.table1",
                         database="--database--",
                         schema="--schema--",
                         columns=[Column(name="name1", data_type="name1-type")],
@@ -186,6 +196,7 @@ class TestMermaidTestRelationship:
                 [
                     Table(
                         name="model.dbt_resto.table1",
+                        node_name="model.dbt_resto.table1",
                         database="--database--",
                         schema="--schema--",
                         columns=[Column(name="name1", data_type="name1-type")],
@@ -193,6 +204,7 @@ class TestMermaidTestRelationship:
                     ),
                     Table(
                         name="model.dbt_resto.table2",
+                        node_name="model.dbt_resto.table2",
                         database="--database--",
                         schema="--schema--",
                         columns=[Column(name="name2", data_type="name2-type")],

--- a/tests/unit/adapters/targets/plantuml/test_plantuml_test_relationship.py
+++ b/tests/unit/adapters/targets/plantuml/test_plantuml_test_relationship.py
@@ -14,6 +14,7 @@ class TestPlantUMLTestRelationship:
                 [
                     Table(
                         name="model.dbt_resto.table1",
+                        node_name="model.dbt_resto.table1",
                         database="--database--",
                         schema="--schema--",
                         columns=[Column(name="name1", data_type="name1-type")],
@@ -35,6 +36,7 @@ class TestPlantUMLTestRelationship:
                 [
                     Table(
                         name="model.dbt_resto.table1",
+                        node_name="model.dbt_resto.table1",
                         database="--database--",
                         schema="--schema--",
                         columns=[Column(name="name1", data_type="name1-type")],
@@ -42,6 +44,7 @@ class TestPlantUMLTestRelationship:
                     ),
                     Table(
                         name="model.dbt_resto.table2",
+                        node_name="model.dbt_resto.table2",
                         database="--database2--",
                         schema="--schema2--",
                         columns=[Column(name="name2", data_type="name2-type2")],
@@ -49,6 +52,7 @@ class TestPlantUMLTestRelationship:
                     ),
                     Table(
                         name="source.dbt_resto.table3",
+                        node_name="source.dbt_resto.table3",
                         database="--database3--",
                         schema="--schema3--",
                         columns=[Column(name="name3", data_type="name3-type3")],
@@ -90,6 +94,7 @@ class TestPlantUMLTestRelationship:
                 [
                     Table(
                         name="model.dbt_resto.table1",
+                        node_name="model.dbt_resto.table1",
                         database="--database--",
                         schema="--schema--",
                         columns=[Column(name="name1", data_type="name1-type")],
@@ -97,6 +102,7 @@ class TestPlantUMLTestRelationship:
                     ),
                     Table(
                         name="model.dbt_resto.table2",
+                        node_name="model.dbt_resto.table2",
                         database="--database2--",
                         schema="--schema2--",
                         columns=[Column(name="name2", data_type="name2-type2")],
@@ -124,6 +130,7 @@ class TestPlantUMLTestRelationship:
                 [
                     Table(
                         name="model.dbt_resto.table1",
+                        node_name="model.dbt_resto.table1",
                         database="--database--",
                         schema="--schema--",
                         columns=[Column(name="name1", data_type="name1-type")],
@@ -142,6 +149,7 @@ class TestPlantUMLTestRelationship:
                 [
                     Table(
                         name="model.dbt_resto.table1",
+                        node_name="model.dbt_resto.table1",
                         database="--database--",
                         schema="--schema--",
                         columns=[Column(name="name1", data_type="name1-type")],
@@ -149,6 +157,7 @@ class TestPlantUMLTestRelationship:
                     ),
                     Table(
                         name="model.dbt_resto.table2",
+                        node_name="model.dbt_resto.table2",
                         database="--database--",
                         schema="--schema--",
                         columns=[Column(name="name2", data_type="name2-type")],
@@ -170,6 +179,7 @@ class TestPlantUMLTestRelationship:
                 [
                     Table(
                         name="model.dbt_resto.table1",
+                        node_name="model.dbt_resto.table1",
                         database="--database--",
                         schema="--schema--",
                         columns=[Column(name="name1", data_type="name1-type")],
@@ -191,6 +201,7 @@ class TestPlantUMLTestRelationship:
                 [
                     Table(
                         name="model.dbt_resto.table1",
+                        node_name="model.dbt_resto.table1",
                         database="--database--",
                         schema="--schema--",
                         columns=[Column(name="name1", data_type="name1-type")],
@@ -198,6 +209,7 @@ class TestPlantUMLTestRelationship:
                     ),
                     Table(
                         name="model.dbt_resto.table2",
+                        node_name="model.dbt_resto.table2",
                         database="--database--",
                         schema="--schema--",
                         columns=[Column(name="name2", data_type="name2-type")],

--- a/tests/unit/adapters/test_filter.py
+++ b/tests/unit/adapters/test_filter.py
@@ -25,21 +25,30 @@ class TestFilter:
         [
             (
                 Table(
-                    name="model.dummy.table1", database="dummydb", schema="dummyschema"
+                    name="irrelevant",
+                    node_name="model.dummy.table1",
+                    database="dummydb",
+                    schema="dummyschema",
                 ),
                 "",
                 True,
             ),
             (
                 Table(
-                    name="model.dummy.table1", database="dummydb", schema="dummyschema"
+                    name="irrelevant",
+                    node_name="model.dummy.table1",
+                    database="dummydb",
+                    schema="dummyschema",
                 ),
                 "table1",
                 False,
             ),
             (
                 Table(
-                    name="model.dummy.table1", database="dummydb", schema="dummyschema"
+                    name="irrelevant",
+                    node_name="model.dummy.table1",
+                    database="dummydb",
+                    schema="dummyschema",
                 ),
                 "model.dummy.table1",
                 True,


### PR DESCRIPTION
resolves #54 

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.
-->

### Description

Add `--entity-name-format` (`-enf` in short) to decide how the table name is generated

Currently, it supports
```
dbterd run --entity-name-format resource.package.model # default
dbterd run --entity-name-format database.schema.table # with fqn of the physical tables
dbterd run --entity-name-format schema.table # with schema.table only
dbterd run --entity-name-format table # with table name only
```

### Checklist

- [x] I have read [the contributing guide](https://github.com/datnguye/dbterd/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have opened an issue to add/update docs, or docs changes are not required/relevant for this PR
