### PR TITLE
Checked map length to prevent errors

### DIFF
--- a/dbterd/adapters/algos/test_relationship.py
+++ b/dbterd/adapters/algos/test_relationship.py
@@ -84,7 +84,7 @@ def get_relationships(manifest, **kwargs):
                             f'{rule.get("c_to")}s', "unknown"
                         )
                     )
-                ).lower(),
+                ).replace("\"","").lower(),
                 str(
                     manifest.nodes[x].test_metadata.kwargs.get("column_name")
                     or manifest.nodes[x].test_metadata.kwargs.get(rule.get("c_from"))
@@ -93,7 +93,7 @@ def get_relationships(manifest, **kwargs):
                             f'{rule.get("c_from")}s', "unknown"
                         )
                     )
-                ).lower(),
+                ).replace("\"","").lower(),
             ],
             type=get_relationship_type(
                 manifest.nodes[x].meta.get(TEST_META_RELATIONSHIP_TYPE, "")
@@ -167,12 +167,8 @@ def get_table_map(test_node, **kwargs):
     map = test_node.depends_on.nodes or []
     rule = get_algo_rule(**kwargs)
     to_model = str(test_node.test_metadata.kwargs.get(rule.get("t_to", "to"), {}))
-
-    if len(map) >= 2 and isinstance(map[1], str):
-        if f'("{map[1].split(".")[-1]}")'.lower() in to_model.replace("'", '"').lower():
-            return [map[1], map[0]]
-    else:
-        return None
+    if f'("{map[1].split(".")[-1]}")'.lower() in to_model.replace("'", '"').lower():
+        return [map[1], map[0]]
 
     return map
 

--- a/dbterd/adapters/algos/test_relationship.py
+++ b/dbterd/adapters/algos/test_relationship.py
@@ -167,8 +167,12 @@ def get_table_map(test_node, **kwargs):
     map = test_node.depends_on.nodes or []
     rule = get_algo_rule(**kwargs)
     to_model = str(test_node.test_metadata.kwargs.get(rule.get("t_to", "to"), {}))
-    if f'("{map[1].split(".")[-1]}")'.lower() in to_model.replace("'", '"').lower():
-        return [map[1], map[0]]
+
+    if len(map) >= 2 and isinstance(map[1], str):
+        if f'("{map[1].split(".")[-1]}")'.lower() in to_model.replace("'", '"').lower():
+            return [map[1], map[0]]
+    else:
+        return None
 
     return map
 


### PR DESCRIPTION
resolves #

Not sure if there is an existing logged issue for this, however:

### Description

This is a fix to an error I get with my manifest.json using dbt-core 1.6.6 and snowflake-adapter 1.6.4. Possibly due to dynamic tables or quoted columns I couldn't quite work it out

```
  File "/dbterd/adapters/algos/test_relationship.py", line 170, in get_table_map
    if f'("{map[1].split(".")[-1]}")'.lower() in to_model.replace("'", '"').lower():
IndexError: list index out of range
```

### Checklist

- [x] I have read [the contributing guide](https://github.com/datnguye/dbterd/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have opened an issue to add/update docs, or docs changes are not required/relevant for this PR
