### PR TITLE
Lowercase node_name in comparison to match even if it is uppercase

### DIFF
--- a/dbterd/adapters/filter.py
+++ b/dbterd/adapters/filter.py
@@ -113,7 +113,7 @@ def is_satisfied_by_exact(table: Table, rule: str = ""):
     """
     if not rule:
         return True
-    return table.node_name == rule
+    return table.node_name.lower() == rule
 
 
 def is_satisfied_by_schema(table: Table, rule: str = ""):

--- a/tests/unit/adapters/test_filter.py
+++ b/tests/unit/adapters/test_filter.py
@@ -53,6 +53,16 @@ class TestFilter:
                 "model.dummy.table1",
                 True,
             ),
+            (
+                Table(
+                    name="irrelevant",
+                    node_name="model.dummy.Table1",
+                    database="dummydb",
+                    schema="dummyschema",
+                ),
+                "model.dummy.table1",
+                True,
+            ),
         ],
     )
     def test_is_satisfied_by_exact(self, table, rule, expected):


### PR DESCRIPTION
resolves https://github.com/datnguye/dbterd/issues/73

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.
-->

### Description
Fixed a bug that prevented ER diagrams from being output when data source table names were capitalized. This is because the `rule` part is `lower()`, but `lower` is not applied in the `is_satisfied_by_exact` function. Therefore, the result of the `is_selected_table` function was determined to be false, and the ER diagram was not output as expected.

- https://github.com/datnguye/dbterd/blob/main/dbterd/adapters/filter.py#L77

<!---
  Describe the Pull Request here. Add any references and info to help reviewers
  understand your changes. Include any tradeoffs you considered.
-->

### Checklist

- [x] I have read [the contributing guide](https://github.com/datnguye/dbterd/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have opened an issue to add/update docs, or docs changes are not required/relevant for this PR
