### PR TITLE
Add `omit_columns` option to mermaid

### DIFF
--- a/dbterd/adapters/targets/mermaid/mermaid_test_relationship.py
+++ b/dbterd/adapters/targets/mermaid/mermaid_test_relationship.py
@@ -42,7 +42,9 @@ def parse(manifest, catalog, **kwargs):
         if kwargs.get("omit_columns", False):
             mermaid += '  "{table_name}" {{\n  }}\n'.format(table_name=table_name)
         else:
-            mermaid += '  "{table_name}" {{\n{columns}\n  }}\n'.format(table_name=table_name, columns=columns)
+            mermaid += '  "{table_name}" {{\n{columns}\n  }}\n'.format(
+                table_name=table_name, columns=columns
+            )
 
     for rel in relationships:
         key_from = f'"{rel.table_map[1]}"'

--- a/dbterd/adapters/targets/mermaid/mermaid_test_relationship.py
+++ b/dbterd/adapters/targets/mermaid/mermaid_test_relationship.py
@@ -32,15 +32,17 @@ def parse(manifest, catalog, **kwargs):
     # https://mermaid.js.org/syntax/entityRelationshipDiagram.html
     mermaid = "erDiagram\n"
     for table in tables:
-        mermaid += '  "{table}" {{\n{columns}\n  }}\n'.format(
-            table=table.name.upper(),
-            columns="\n".join(
-                [
-                    f'    {x.data_type.replace(" ","-")} {x.name.replace(" ","-")}'
-                    for x in table.columns
-                ]
-            ),
+        table_name = table.name.upper()
+        columns = "\n".join(
+            [
+                f'    {x.data_type.replace(" ","-")} {x.name.replace(" ","-")}'
+                for x in table.columns
+            ]
         )
+        if kwargs.get("omit_columns", False):
+            mermaid += '  "{table_name}" {{\n  }}\n'.format(table_name=table_name)
+        else:
+            mermaid += '  "{table_name}" {{\n{columns}\n  }}\n'.format(table_name=table_name, columns=columns)
 
     for rel in relationships:
         key_from = f'"{rel.table_map[1]}"'

--- a/dbterd/cli/params.py
+++ b/dbterd/cli/params.py
@@ -63,6 +63,16 @@ def common_params(func):
         show_default=True,
         type=click.STRING,
     )
+    @click.option(
+        "--omit_columns",
+        help=(
+            "Flag to omit columns in diagram. ",
+            "Currently only mermaid is supported"
+        ),
+        is_flag=True,
+        default=False,
+        show_default=True,
+    )
     @functools.wraps(func)
     def wrapper(*args, **kwargs):
         return func(*args, **kwargs)  # pragma: no cover

--- a/dbterd/cli/params.py
+++ b/dbterd/cli/params.py
@@ -67,7 +67,7 @@ def common_params(func):
         "--omit_columns",
         help=(
             "Flag to omit columns in diagram. ",
-            "Currently only mermaid is supported"
+            "Currently only mermaid is supported",
         ),
         is_flag=True,
         default=False,

--- a/dbterd/cli/params.py
+++ b/dbterd/cli/params.py
@@ -65,10 +65,7 @@ def common_params(func):
     )
     @click.option(
         "--omit_columns",
-        help=(
-            "Flag to omit columns in diagram. ",
-            "Currently only mermaid is supported",
-        ),
+        help="Flag to omit columns in diagram. Currently only mermaid is supported",
         is_flag=True,
         default=False,
         show_default=True,

--- a/dbterd/cli/params.py
+++ b/dbterd/cli/params.py
@@ -64,7 +64,7 @@ def common_params(func):
         type=click.STRING,
     )
     @click.option(
-        "--omit_columns",
+        "--omit-columns",
         help="Flag to omit columns in diagram. Currently only mermaid is supported",
         is_flag=True,
         default=False,

--- a/docs/nav/guide/cli-references.md
+++ b/docs/nav/guide/cli-references.md
@@ -55,6 +55,8 @@ Command to generate diagram-as-a-code file
         -rt, --resource-type TEXT     Specified dbt resource type(seed, model,
                                         source, snapshot),default:model, use examples,
                                         -rt model -rt source
+        --omit-columns                Flag to omit columns in diagram. Currently
+                                        only mermaid is supported
         -h, --help                    Show this message and exit.
     ```
 
@@ -173,7 +175,6 @@ Configure the path to directory containing the output diagram file.
 
 ### dbterd run --target (-t)
 
-Target to the diagram-as-code platform
 > Default to `dbml`
 
 Supported target, please visit [Generate the Targets](https://dbterd.datnguyen.de/latest/nav/guide/targets/generate-dbml.html)
@@ -230,6 +231,19 @@ In the above:
 
     ```bash
     dbterd run --algo "test_relationship:(name:foreign_key|c_from:fk_column_name|c_to:pk_column_name)"
+    ```
+
+### dbterd run --omit-columns
+
+Flag to omit columns in diagram. Currently only mermaid is supported
+
+> Default to `False`
+
+**Examples:**
+=== "CLI"
+
+    ```bash
+    dbterd run --target mermaid --omit-columns
     ```
 
 ### dbterd run --manifest-version (-mv)

--- a/tests/unit/adapters/targets/mermaid/test_mermaid_test_relationship.py
+++ b/tests/unit/adapters/targets/mermaid/test_mermaid_test_relationship.py
@@ -8,7 +8,7 @@ from dbterd.adapters.targets.mermaid import mermaid_test_relationship as engine
 
 class TestMermaidTestRelationship:
     @pytest.mark.parametrize(
-        "tables, relationships, select, exclude, resource_type, expected",
+        "tables, relationships, select, exclude, resource_type, omit_columns, expected",
         [
             (
                 [
@@ -25,6 +25,7 @@ class TestMermaidTestRelationship:
                 [],
                 [],
                 ["model"],
+                False,
                 """erDiagram
                   "MODEL.DBT_RESTO.TABLE1" {
                       name1-type name1
@@ -73,6 +74,7 @@ class TestMermaidTestRelationship:
                 [],
                 [],
                 ["model", "source"],
+                False,
                 """erDiagram
                   "MODEL.DBT_RESTO.TABLE1" {
                       name1-type name1
@@ -118,6 +120,7 @@ class TestMermaidTestRelationship:
                 ["schema:--schema--"],
                 [],
                 ["model", "source"],
+                False,
                 """erDiagram
                     "MODEL.DBT_RESTO.TABLE1" {
                         name1-type name1
@@ -139,6 +142,7 @@ class TestMermaidTestRelationship:
                 [],
                 ["model.dbt_resto.table1"],
                 ["model"],
+                False,
                 """erDiagram
                 """,
             ),
@@ -165,6 +169,7 @@ class TestMermaidTestRelationship:
                 ["model.dbt_resto"],
                 ["model.dbt_resto.table2"],
                 ["model"],
+                False,
                 """erDiagram
                     "MODEL.DBT_RESTO.TABLE1" {
                         name1-type name1
@@ -186,6 +191,7 @@ class TestMermaidTestRelationship:
                 ["schema:", "wildcard:", ""],
                 [],
                 ["model"],
+                False,
                 """erDiagram
                     "MODEL.DBT_RESTO.TABLE1" {
                         name1-type name1
@@ -215,16 +221,45 @@ class TestMermaidTestRelationship:
                 ["schema:--schema--,wildcard:*dbt_resto.table*"],
                 ["wildcard:*table2"],
                 ["model"],
+                False,
                 """erDiagram
                     "MODEL.DBT_RESTO.TABLE1" {
                         name1-type name1
                     }
                 """,
             ),
+            (
+                [
+                    Table(
+                        name="model.dbt_resto.table1",
+                        node_name="model.dbt_resto.table1",
+                        database="--database--",
+                        schema="--schema--",
+                        columns=[Column(name="name1", data_type="name1-type")],
+                        raw_sql="--irrelevant--",
+                    )
+                ],
+                [],
+                [],
+                [],
+                ["model"],
+                True,
+                """erDiagram
+                  "MODEL.DBT_RESTO.TABLE1" {
+                  }
+                """,
+            ),
         ],
     )
     def test_parse(
-        self, tables, relationships, select, exclude, resource_type, expected
+        self,
+        tables,
+        relationships,
+        select,
+        exclude,
+        resource_type,
+        omit_columns,
+        expected,
     ):
         with mock.patch(
             "dbterd.adapters.algos.base.get_tables",
@@ -239,6 +274,7 @@ class TestMermaidTestRelationship:
                     catalog="--catalog--",
                     select=select,
                     exclude=exclude,
+                    omit_columns=omit_columns,
                     resource_type=resource_type,
                 )
                 print("mermaid ", mermaid.replace(" ", "").replace("\n", ""))


### PR DESCRIPTION
resolves https://github.com/datnguye/dbterd/issues/78

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.
-->

### Description
I added `--omit_columns` option to omit columns from diagrams when the output format is mermaid.

I thought about omitting columns for `--target` other than mermaid, but since dbml, for example, requires at least one column, I decided to support only `--target = mermaid`.

<!---
  Describe the Pull Request here. Add any references and info to help reviewers
  understand your changes. Include any tradeoffs you considered.
-->

### Checklist

- [x] I have read [the contributing guide](https://github.com/datnguye/dbterd/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have opened an issue to add/update docs, or docs changes are not required/relevant for this PR
