### PR TITLE
Allows drawing recursive relationships

### DIFF
--- a/dbterd/adapters/algos/base.py
+++ b/dbterd/adapters/algos/base.py
@@ -584,6 +584,12 @@ def get_table_map(test_node, **kwargs) -> List[str]:
         list: [to model, from model]
     """
     map = test_node.depends_on.nodes or []
+
+    # Recursive relation case
+    # `from` and `to` will be identical and `test_node.depends_on.nodes` will contain only one element
+    if len(map) == 1:
+        return [map[0], map[0]]
+
     rule = get_algo_rule(**kwargs)
     to_model = str(test_node.test_metadata.kwargs.get(rule.get("t_to", "to"), {}))
     if f'("{map[1].split(".")[-1]}")'.lower() in to_model.replace("'", '"').lower():

--- a/tests/unit/adapters/algos/test_test_relationship.py
+++ b/tests/unit/adapters/algos/test_test_relationship.py
@@ -142,6 +142,14 @@ class DummyManifestRel:
                 nodes=["model.dbt_resto.table-r1", "model.dbt_resto.table-r2"]
             ),
         ),
+        "test.dbt_resto.relationships_table1_recursive": ManifestNode(
+            test_metadata=ManifestNodeTestMetaData(
+                kwargs={"column_name": "f1", "field": "f2", "to": "ref('table1')"}
+            ),
+            meta={},
+            columns={},
+            depends_on=ManifestNodeDependsOn(nodes=["model.dbt_resto.table1"]),
+        ),
     }
 
 
@@ -352,6 +360,11 @@ class TestAlgoTestRelationship:
                             "model.dbt_resto.table-r2",
                             "model.dbt_resto.table-r1",
                         ],
+                        column_map=["f2", "f1"],
+                    ),
+                    Ref(
+                        name="test.dbt_resto.relationships_table1_recursive",
+                        table_map=["model.dbt_resto.table1", "model.dbt_resto.table1"],
                         column_map=["f2", "f1"],
                     ),
                 ],


### PR DESCRIPTION
resolves https://github.com/datnguye/dbterd/issues/88

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.
-->

### Description
This modification allows a diagram to be drawn even if it has the following recursive relationship.

```mermaid
erDiagram
  "MY_PROJECT.CATEGORY" {
  }
  "MY_PROJECT.CATEGORY" }|--|| "MY_PROJECT.CATEGORY": categoryid--parentCategoryId
```


<!---
  Describe the Pull Request here. Add any references and info to help reviewers
  understand your changes. Include any tradeoffs you considered.
-->

### Checklist

- [x] I have read [the contributing guide](https://github.com/datnguye/dbterd/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have opened an issue to add/update docs, or docs changes are not required/relevant for this PR
