### PR TITLE
feat(api): `find_related_nodes_by_id` shouldn't raise exception

### DIFF
--- a/dbterd/adapters/algos/test_relationship.py
+++ b/dbterd/adapters/algos/test_relationship.py
@@ -1,7 +1,5 @@
 from typing import List, Tuple, Union
 
-import click
-
 from dbterd.adapters.algos import base
 from dbterd.adapters.filter import is_selected_table
 from dbterd.adapters.meta import Ref, Table
@@ -121,14 +119,15 @@ def find_related_nodes_by_id(
     Returns:
         List[str]: Manifest nodes' unique ID
     """
-    if type is not None:
-        raise click.BadParameter("Not supported manifest type")
+    found_nodes = [node_unique_id]
+    if type == "metadata":
+        return found_nodes  # not supported yet, returned input only
 
     rule = base.get_algo_rule(**kwargs)
     test_nodes = base.get_test_nodes_by_rule_name(
         manifest=manifest, rule_name=rule.get("name").lower()
     )
-    found_nodes = [node_unique_id]
+
     for test_node in test_nodes:
         nodes = manifest.nodes[test_node].depends_on.nodes or []
         if node_unique_id in nodes:

--- a/tests/unit/adapters/algos/test_test_relationship.py
+++ b/tests/unit/adapters/algos/test_test_relationship.py
@@ -866,11 +866,10 @@ class TestAlgoTestRelationship:
         with pytest.raises(click.BadParameter):
             base_algo.get_relationships_from_metadata(data=data, **kwargs)
 
-    def test_find_related_nodes_by_id_error(self):
-        with pytest.raises(click.BadParameter):
-            test_relationship.find_related_nodes_by_id(
-                manifest="irrelevant", type="metadata", node_unique_id="irrelevant"
-            )
+    def test_find_related_nodes_by_id_not_supported_type(self):
+        assert ["model.p.abc"] == test_relationship.find_related_nodes_by_id(
+            manifest="irrelevant", type="metadata", node_unique_id="model.p.abc"
+        )
 
     def test_find_related_nodes_by_id(self):
         assert sorted(["model.dbt_resto.table1", "model.dbt_resto.table2"]) == sorted(


### PR DESCRIPTION
`find_related_nodes_by_id` shouldn't raise exception but returns the input right away when type is not supported yet