### PR TITLE
fix: mermaid complex types

### DIFF
--- a/dbterd/adapters/targets/mermaid.py
+++ b/dbterd/adapters/targets/mermaid.py
@@ -42,7 +42,7 @@ def match_complex_column_type(column_type: str) -> Optional[str]:
     Returns:
         Optional[str]: Returns root type if input type is nested complex type, otherwise returns `None` for primitive types
     """
-    pattern = r"(\w+)<(\w+\s+\w+(\s*,\s*\w+\s+\w+)*)>"
+    pattern = r"(\w+)<.*>"
     match = re.match(pattern, column_type)
     if match:
         return match.group(1)

--- a/dbterd/adapters/targets/mermaid.py
+++ b/dbterd/adapters/targets/mermaid.py
@@ -42,7 +42,7 @@ def match_complex_column_type(column_type: str) -> Optional[str]:
     Returns:
         Optional[str]: Returns root type if input type is nested complex type, otherwise returns `None` for primitive types
     """
-    pattern = r"(\w+)<.*>"
+    pattern = r"(\w+)<(\w+\s+\w+(\s*,\s*\w+\s+\w+)*)>"
     match = re.match(pattern, column_type)
     if match:
         return match.group(1)

--- a/tests/unit/adapters/targets/mermaid/test_mermaid_column_types.py
+++ b/tests/unit/adapters/targets/mermaid/test_mermaid_column_types.py
@@ -15,9 +15,11 @@ column_types = [
     ("array<struct<string a_id, string b_id>>", "array[OMITTED]"),
 ]
 
+
 @pytest.mark.parametrize("input,expected", complex_column_types)
 def test_match_complex_column_type(input, expected):
     assert mermaid.match_complex_column_type(input) == expected
+
 
 @pytest.mark.parametrize("input,expected", column_types)
 def test_replace_column_type(input, expected):

--- a/tests/unit/adapters/targets/mermaid/test_mermaid_column_types.py
+++ b/tests/unit/adapters/targets/mermaid/test_mermaid_column_types.py
@@ -1,0 +1,24 @@
+import pytest
+
+from dbterd.adapters.targets import mermaid
+
+complex_column_types = [
+    ("string", None),
+    ("struct<string a, string b>", "struct"),
+    ("array<struct<string a, string b>>", "array"),
+    ("array<struct<string a_id, string b_id>>", "array"),
+]
+column_types = [
+    ("string", "string"),
+    ("struct<string a, string b>", "struct[OMITTED]"),
+    ("array<struct<string a, string b>>", "array[OMITTED]"),
+    ("array<struct<string a_id, string b_id>>", "array[OMITTED]"),
+]
+
+@pytest.mark.parametrize("input,expected", complex_column_types)
+def test_match_complex_column_type(input, expected):
+    assert mermaid.match_complex_column_type(input) == expected
+
+@pytest.mark.parametrize("input,expected", column_types)
+def test_replace_column_type(input, expected):
+    assert mermaid.replace_column_type(input) == expected


### PR DESCRIPTION
Previously, from a complex nested type like `a<b<c d, e f>>`, the mermaid adapter would ignore `a` and capture `b`, `c d` and `, e f`.
Now it captures `a` and `b<c d, e f>`, which is discarded as far as I can see.

I've simplified the regex expression and tested with the obvious cases, but I'm not sure if the new regex might miss some edge cases. It'd be nice to add more tests if you think I might be missing something :) 

I'm pushing twice, without the fix implemented and then with the fix, ~~so that you can see the testing logs in both cases.~~ well workflow needs approval anyway 😅 

Thanks for your work!

### Checklist

- [x] I have read [the contributing guide](https://github.com/datnguye/dbterd/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have opened an issue to add/update docs, or docs changes are not required/relevant for this PR
