### PR TITLE
feat: enable label override for the display name of tables and refs

### DIFF
--- a/dbterd/adapters/algos/base.py
+++ b/dbterd/adapters/algos/base.py
@@ -480,7 +480,7 @@ def get_relationships_from_metadata(data=None, **kwargs) -> list[Ref]:
                             .lower(),
                         ],
                         type=get_relationship_type(test_meta.get(TEST_META_RELATIONSHIP_TYPE, "")),
-                        label=test_meta.get("label"),
+                        relationship_label=test_meta.get("relationship_label"),
                     )
                 )
 
@@ -523,7 +523,7 @@ def get_relationships(manifest: Manifest, **kwargs) -> list[Ref]:
                 .lower(),
             ],
             type=get_relationship_type(manifest.nodes[x].meta.get(TEST_META_RELATIONSHIP_TYPE, "")),
-            label=manifest.nodes[x].meta.get("label"),
+            relationship_label=manifest.nodes[x].meta.get("relationship_label"),
         )
         for x in get_test_nodes_by_rule_name(manifest=manifest, rule_name=rule.get("name").lower())
     ]
@@ -557,7 +557,7 @@ def make_up_relationships(relationships: Optional[list[Ref]] = None, tables: Opt
             ],
             column_map=x.column_map,
             type=x.type,
-            label=x.label,
+            relationship_label=x.relationship_label,
         )
         for x in relationships
         if x.table_map[0] in node_names and x.table_map[1] in node_names

--- a/dbterd/adapters/meta.py
+++ b/dbterd/adapters/meta.py
@@ -36,7 +36,7 @@ class Ref:
     table_map: tuple[str, str]
     column_map: tuple[str, str]
     type: str = "n1"
-    label: Optional[str] = None
+    relationship_label: Optional[str] = None
 
 
 @dataclass

--- a/dbterd/adapters/targets/mermaid.py
+++ b/dbterd/adapters/targets/mermaid.py
@@ -116,8 +116,8 @@ def parse(manifest: Manifest, catalog: Catalog, **kwargs) -> str:
         reference_text = replace_column_name(rel.column_map[0])
         if rel.column_map[0] != rel.column_map[1]:
             reference_text += f"--{replace_column_name(rel.column_map[1])}"
-        if hasattr(rel, "label") and rel.label:
-            reference_text = replace_column_name(rel.label)
+        if hasattr(rel, "relationship_label") and rel.relationship_label:
+            reference_text = replace_column_name(rel.relationship_label)
         mermaid += f"  {key_from.upper()} {get_rel_symbol(rel.type)} {key_to.upper()}: {reference_text}\n"
 
     return mermaid

--- a/tests/unit/adapters/targets/mermaid/test_mermaid_test_relationship.py
+++ b/tests/unit/adapters/targets/mermaid/test_mermaid_test_relationship.py
@@ -350,7 +350,7 @@ class TestMermaidTestRelationship:
                         name="test.dbt_resto.relationships_table1",
                         table_map=["model.dbt_resto.table2", "model.dbt_resto.table1"],
                         column_map=["name2.first_name", "name1.first_name"],
-                        label="Preferred_Relationship_Name",
+                        relationship_label="Preferred_Relationship_Name",
                     ),
                 ],
                 [],


### PR DESCRIPTION
A potential approach to the discussion https://github.com/datnguye/dbterd/discussions/129 to allow custom overrides. This approach uses the default values (fully qualified names for db objects, name of the columns for relationships) unless a `label` is specified in the `meta` option.
Currently only implemented for test_relationships, but not for the semantic model.

e.g. taking as input:

```yaml

version 2:

models:

    - name: sample1
    - name: sample2
      columns:
        - name: date_column
          data_tests:
          - relationships:
              to: ref('sample1')
              field: date_column
              meta:
                relationship_type: many-to-one
 ```
by including the custom label value

```diff 

    - name: sample1
+      meta:
+        label: alternative_sample_1

...

                relationship_type: many-to-one
+               relationship_label: preferred_relationship_name

```

to obtain a expanded properties file like:


```yaml

version 2:

models:

    - name: sample1
      meta:
         label: alternative_sample_1    

    - name: sample2
      columns:
        - name: date_column
          data_tests:
          - relationships:
              to: ref('sample1')
              field: date_column
              meta:
                relationship_type: many-to-one
                relationship_label: preferred_relationship_name

 ```

Changes the output from:
 
 
 ```mermaid

erDiagram
  
  "MODEL.DVD_UTILS.SAMPLE1" {
    date date_column
  }
  "MODEL.DVD_UTILS.SAMPLE2" {
    date date_column
    date date_column_b
  }
  "MODEL.DVD_UTILS.SAMPLE2" }|--|| "MODEL.DVD_UTILS.SAMPLE1": date_column
```

to:

```mermaid

erDiagram
 
  "MODEL.DVD_UTILS.SAMPLE1"["ALTERNATIVE_SAMPLE_1"] {
    date date_column
  }
  "MODEL.DVD_UTILS.SAMPLE2" {
    date date_column
    date date_column_b
  }
  "MODEL.DVD_UTILS.SAMPLE2" }|--|| "MODEL.DVD_UTILS.SAMPLE1": preferred_relationship_name
```